### PR TITLE
Major code refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *.pyc
-MANIFEST
 dist/
 build/
 *.egg-info/
+*.tox
+*.pytest*
+*.idea

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,0 @@
-include README.md
-include LICENSE
-include Makefile

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,12 @@ package:
 	python setup.py clean
 	python setup.py sdist
 
+test:
+	pytest -v
+
 clean:
 	rm -rf build
 	rm -rf dist/
+	rm -rf *.egg-info
+	rm -rf .pytest_cache
+	rm -rf .tox

--- a/README.md
+++ b/README.md
@@ -1,14 +1,13 @@
 # NTRIP Browser
 
-A simple Python API for browse NTRIP (Networked Transport of RTCM via Internet Protocol).  
+A Python API for browsing NTRIP (Networked Transport of RTCM via Internet Protocol).
 
-## Dependencies
-
-`geopy`
-`chardet`
-`texttable`
-
-The package was tested with **Python 2.7**
+## Requirements
+ - geopy
+ - pycurl
+ - chardet
+ - texttable
+ - Python 2.6–2.7 & 3.4–3.6
 
 ## Installation
 
@@ -19,10 +18,10 @@ The package was tested with **Python 2.7**
 ## Usage 
 
 ```
-ntripbrowser [-h] [-p] [-t] [-c] url  
+ntripbrowser [-h] [-p] [-t] [-c] host
 
 positional arguments:  
-  url                   NTRIP source table address
+  host                  NTRIP source table host address
 
 optional arguments:  
   -h, --help            Show this help message and exit  
@@ -31,26 +30,37 @@ optional arguments:
   -c, --coordinates     Add NTRIP station distance to this coordinate
  ```
 
+#### CLI workflow example:
+
+    ntripbrowser cddis-caster.gsfc.nasa.gov -p 443 -t 5 -c 1.0 2.0
+
 ## Package API
+#### Workflow example:
 
 ```python
-get_mountpoints(url, timeout=None, coordinates=None)
+browser = NtripBrowser(host, port=2101, timeout=None, coordinates=None)
+browser.get_mountpoints()
+browser.host = another_host
+browser.get_mountpoints()
 ```
+
 #### Arguments:
 
- - `url`    
- 
-> Use `url` only with *http://* to pass url variable in function.       
-> Standard port is 2101, use `:port` after `url` to set another one.    
-> Example: *http://192.168.1.0:2101* or  *http://ntrip.emlid.com:2101*.
+ - `host`
+
+> NTRIP caster host.
+> Standard port is 2101, use `:port` optional argument to set another one.
 
 #### Optional arguments:
 
+ - `port`
+
+> NTRIP caster port.
+
  - `timeout`    
  
-> Use `timeout` to pass timeout in function. It must be integer.    
-
- - `coordinates`    
+> Use `timeout` to define, how long to wait for a connection to NTRIP caster.
+ - `coordinates`
  
 > Use `coordinates` to pass your position coordinates in function and get distance to NTRIP station.    
 > Form of coordiantes must be `(x, y)` or `(x.x, y.y)` of latitude, longitude.
@@ -63,10 +73,25 @@ As a result you'll get a dictionary consisting of a lists of dictionaries with s
 
 - NET stations: `"ID", "Operator", "Authentication", "Fee", "Web-Net", "Web-Str", "Web-Reg", "Other Details", "Distance"`    
 
-- STR stations: `"Mountpoint", "ID", "Format", "Format-Details","Carrier", "Nav-System", "Network", "Country", "Latitude", "Longitude", "NMEA", "Solution", "Generator", "Compr-Encrp", "Authentication", "Fee", "Bitrate", "Other Details", "Distance"`    
+- STR stations: `"Mountpoint", "ID", "Format", "Format-Details","Carrier", "Nav-System", "Network", "Country", "Latitude", "Longitude", "NMEA", "Solution", "Generator", "Compr-Encryp", "Authentication", "Fee", "Bitrate", "Other Details", "Distance"`
 
-## Example    
-```python
-from ntripbrowser import get_mountpoints
-print get_mountpoints('http://emlid.ntrip.com:2101', 1, (0.0, 0.0))
-```
+#### Exceptions
+
+ - `ntripbrowser.NtripbrowserError` - base class for all ntripbrowser exceptions.
+ - `ntripbrowser.UnableToConnect` - raised when ntripbrowser could not connect to the assigned url.
+ - `ntripbrowser.NoDataReceivedFromCaster` - raised when ntripbrowser could not find any data on the page.
+ - `ntripbrowser.ExceededTimeoutError` - raised when connection timeout is exceeded.
+ - `ntripbrowser.HandshakeFiledError` - raised when connection handshake is failed.
+
+## To test
+
+    make test
+
+#### Known Issues
+Tests with `tox` may fail if python*-dev is not installed.
+So, you need to install python2.7-dev and python3.6-dev:
+
+    sudo apt-get install python2.7-dev
+    sudo apt-get install python3.6-dev
+
+

--- a/ntripbrowser/__init__.py
+++ b/ntripbrowser/__init__.py
@@ -1,1 +1,4 @@
-from .ntripbrowser import get_mountpoints, NtripError
+from .ntripbrowser import NtripBrowser
+from .exceptions import (NtripbrowserError, ExceededTimeoutError, NoDataFoundOnPage,
+                         NoDataReceivedFromCaster, UnableToConnect, HandshakeFiledError)
+from .constants import STR_HEADERS, NET_HEADERS, CAS_HEADERS

--- a/ntripbrowser/browser.py
+++ b/ntripbrowser/browser.py
@@ -1,0 +1,77 @@
+import pydoc
+import pager
+import argparse
+
+from texttable import Texttable
+
+from ntripbrowser import NtripBrowser
+from ntripbrowser import ExceededTimeoutError, UnableToConnect, NoDataReceivedFromCaster, HandshakeFiledError
+from ntripbrowser import CAS_HEADERS, STR_HEADERS, NET_HEADERS
+
+
+SCREEN_WIDTH = pager.getwidth()
+
+
+def argparser():
+    parser = argparse.ArgumentParser(description='Parse NTRIP sourcetable')
+    parser.add_argument('url', help='NTRIP sourcetable address')
+    parser.add_argument('-p', '--port', type=int,
+                        help='Set url port. Standard port is 2101', default=2101)
+    parser.add_argument('-t', '--timeout', type=int,
+                        help='add timeout', default=4)
+    parser.add_argument('-c', '--coordinates',
+                        help='Add NTRIP station distance to this coordinate', nargs=2)
+
+    return parser.parse_args()
+
+
+def display_ntrip_table(ntrip_table):
+    table_cas = compile_ntrip_table(ntrip_table['cas'], CAS_HEADERS)
+    table_net = compile_ntrip_table(ntrip_table['net'], NET_HEADERS)
+    table_str = compile_ntrip_table(ntrip_table['str'], STR_HEADERS)
+
+    pydoc.pager((
+            'CAS TABLE'.center(SCREEN_WIDTH, '=') + '\n' + table_cas + 4 * '\n' +
+            'NET TABLE'.center(SCREEN_WIDTH, '=') + '\n' + table_net + 4 * '\n' +
+            'STR TABLE'.center(SCREEN_WIDTH, '=') + '\n' + table_str
+    ))
+
+
+def compile_ntrip_table(table, headers):
+    table_to_draw = Texttable(max_width=SCREEN_WIDTH)
+    for row in table:
+        row_to_draw = []
+        for header in headers:
+            try:
+                row_to_draw.append(row[header])
+            except KeyError:
+                row_to_draw.append(None)
+        table_to_draw.add_rows((headers, row_to_draw))
+
+    return table_to_string(table_to_draw)
+
+
+def table_to_string(table):
+    try:
+        return str(table.draw()).center(SCREEN_WIDTH, ' ')  # python3
+    except UnicodeEncodeError:
+        return table.draw().center(SCREEN_WIDTH, ' ')       # python2
+    except TypeError:
+        return ''
+
+
+def main():
+    args = argparser()
+    browser = NtripBrowser(args.url, port=args.port, timeout=args.timeout, coordinates=args.coordinates)
+    try:
+        ntrip_table = browser.get_mountpoints()
+    except ExceededTimeoutError:
+        print('Connection timed out')
+    except UnableToConnect:
+        print('Unable to connect to NTRIP caster')
+    except NoDataReceivedFromCaster:
+        print('No data received from NTRIP caster')
+    except HandshakeFiledError:
+        print('Unable to connect to NTRIP caster, handshake error')
+    else:
+        display_ntrip_table(ntrip_table)

--- a/ntripbrowser/constants.py
+++ b/ntripbrowser/constants.py
@@ -1,0 +1,16 @@
+CAS_HEADERS = ('Host', 'Port', 'ID', 'Operator',
+               'NMEA', 'Country', 'Latitude', 'Longitude',
+               'FallbackHost', 'FallbackPort', 'Site', 'Other Details', 'Distance')
+
+NET_HEADERS = ('ID', 'Operator', 'Authentication',
+               'Fee', 'Web-Net', 'Web-Str', 'Web-Reg', 'Other Details', 'Distance')
+
+STR_HEADERS = ('Mountpoint', 'ID', 'Format', 'Format-Details',
+               'Carrier', 'Nav-System', 'Network', 'Country', 'Latitude',
+               'Longitude', 'NMEA', 'Solution', 'Generator', 'Compr-Encryp',
+               'Authentication', 'Fee', 'Bitrate', 'Other Details', 'Distance')
+
+PYCURL_COULD_NOT_RESOLVE_HOST_ERRNO = 6
+PYCURL_CONNECTION_FAILED_ERRNO = 7
+PYCURL_TIMEOUT_ERRNO = 28
+PYCURL_HANDSHAKE_ERRNO = 35

--- a/ntripbrowser/exceptions.py
+++ b/ntripbrowser/exceptions.py
@@ -1,0 +1,22 @@
+class NtripbrowserError(Exception):
+    pass
+
+
+class UnableToConnect(NtripbrowserError):
+    pass
+
+
+class ExceededTimeoutError(NtripbrowserError):
+    pass
+
+
+class NoDataFoundOnPage(NtripbrowserError):
+    pass
+
+
+class HandshakeFiledError(NtripbrowserError):
+    pass
+
+
+class NoDataReceivedFromCaster(NtripbrowserError):
+    pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
-chardet==2.3.0
-geopy==1.11.0
-texttable==0.9.0
+chardet==3.0.4
+geopy==1.14.0
+pager==3.3
+pycurl==7.43.0.1
+texttable==1.2.1
+tox==3.0.0
+mock==2.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[metadata]
-description-file = README.md

--- a/setup.py
+++ b/setup.py
@@ -6,14 +6,14 @@ setup(
     author='Andrew Yushkevich',
     author_email='andrew.yushkevich@emlid.com',
     packages=['ntripbrowser'],
-    install_requires=['chardet', 'geopy','texttable'],
-    license = 'BSD-3-Clause',
+    install_requires=['chardet', 'geopy', 'texttable', 'pager', 'pycurl'],
+    tests_requires=['pytest', 'mock', 'tox'],
+    license='BSD-3-Clause',
     url='https://github.com/emlid/ntripbrowser.git',
-    description='NTRIP Browser for terminal',
-    long_description=open('README.md').read(),
-    entry_points = {
+    description='NTRIP cli browser',
+    entry_points={
         'console_scripts': [
-            'ntripbrowser = ntripbrowser.ntripbrowser:main',
+            'ntripbrowser = ntripbrowser.browser:main',
         ],
     },
 )

--- a/tests/test_ntripbrowser.py
+++ b/tests/test_ntripbrowser.py
@@ -1,0 +1,255 @@
+import pytest
+from mock import patch
+from collections import namedtuple
+
+from ntripbrowser import (NtripBrowser, UnableToConnect, ExceededTimeoutError,
+                          NoDataReceivedFromCaster, HandshakeFiledError)
+import testing_content
+
+
+Caster = namedtuple('Caster', ['url', 'port'])
+
+HTTP_CASTER = Caster('euref-ip.net', 2101)
+HTTPS_CASTER = Caster('cddis-caster.gsfc.nasa.gov', 443)
+WIN1252_CASTER = Caster('rtk.geospider.ru', 8032)
+HTML_PAGE_CASTER = Caster('193.190.66.25', 2102)
+HEADERLESS_CASTER = Caster('195.77.88.220', 2101)
+NONEXISTENT_CASTER = Caster('emlid.com', 443)
+INCOMPLETE_DATA_CASTER = Caster('rtk.topnetlive.com', 2101)
+
+
+def run_caster_test(caster):
+    browser = NtripBrowser(caster.url, caster.port)
+    try:
+        browser.get_mountpoints()
+    except (UnableToConnect, ExceededTimeoutError, HandshakeFiledError):
+        pass
+
+
+def test_http_caster():
+    run_caster_test(HTTP_CASTER)
+
+
+def test_https_caster():
+    run_caster_test(HTTPS_CASTER)
+
+
+def test_win1252_caster():
+    run_caster_test(WIN1252_CASTER)
+
+
+def test_html_page_caster():
+    run_caster_test(HTML_PAGE_CASTER)
+
+
+def test_headerless_caster():
+    run_caster_test(HEADERLESS_CASTER)
+
+
+def test_incomplete_data_caster():
+    run_caster_test(INCOMPLETE_DATA_CASTER)
+
+
+def test_nonexistent_caster():
+    with pytest.raises(NoDataReceivedFromCaster):
+        run_caster_test(NONEXISTENT_CASTER)
+
+
+def test_reassign_parameters():
+    browser = NtripBrowser('example', 1234)
+    assert [
+               'http://example:1234',
+               'http://example:1234/sourcetable.txt',
+               'https://example:1234',
+               'https://example:1234/sourcetable.txt',
+           ] == browser.urls
+    browser.host = 'http://sample'
+    browser.port = 4321
+    assert [
+               'http://sample:4321',
+               'http://sample:4321/sourcetable.txt',
+               'https://sample:4321',
+               'https://sample:4321/sourcetable.txt',
+           ] == browser.urls
+    browser.host = 'https://eg'
+    browser.port = 123
+    assert [
+               'http://eg:123',
+               'http://eg:123/sourcetable.txt',
+               'https://eg:123',
+               'https://eg:123/sourcetable.txt',
+           ] == browser.urls
+
+
+@patch.object(NtripBrowser, '_read_data', lambda self, url: b'<Some invalid NTRIP data>')
+def test_invalid_data():
+    browser = NtripBrowser('example', 1234)
+    with pytest.raises(NoDataReceivedFromCaster):
+        browser.get_mountpoints()
+
+
+@patch.object(NtripBrowser, '_read_data', lambda self, url: testing_content.VALID_NET_NTRIP)
+def test_valid_net_data():
+    browser = NtripBrowser('test', 1234)
+    assert browser.get_mountpoints() == {
+        'cas': [],
+        'net': [
+            {
+                'Authentication': 'B',
+                'Distance': None,
+                'Fee': 'N',
+                'ID': 'Str1',
+                'Operator': 'Str2',
+                'Other Details': 'none',
+                'Web-Net': 'https://example.htm',
+                'Web-Reg': 'http://sample',
+                'Web-Str': 'http://example.htm'
+            }
+        ],
+        'str': []
+    }
+
+
+@patch.object(NtripBrowser, '_read_data', lambda self, url: testing_content.VALID_STR_NTRIP)
+def test_valid_str_data():
+    browser = NtripBrowser('test', 1234)
+    assert browser.get_mountpoints() == {
+        'cas': [],
+        'net': [],
+        'str': [
+            {
+                'Carrier': 'https://example2.htm',
+                'Country': 'none',
+                'Distance': None,
+                'Format': 'B',
+                'Format-Details': 'N',
+                'ID': 'Str4',
+                'Mountpoint': 'Str3',
+                'Nav-System': 'http://example2.htm',
+                'Network': 'http://sample2'
+             }
+        ]
+    }
+
+
+@patch.object(NtripBrowser, '_read_data', lambda self, url: testing_content.VALID_CAS_NTRIP)
+def test_valid_cas_data():
+    browser = NtripBrowser('test', 1234)
+    assert browser.get_mountpoints() == {
+        'cas': [
+            {
+                'Country': 'Null',
+                'Distance': None,
+                'FallbackHost': '1.2.3.4',
+                'FallbackPort': '5',
+                'Host': 'example',
+                'ID': 'NtripCaster',
+                'Latitude': '11',
+                'Longitude': '22.33',
+                'NMEA': '0',
+                'Operator': 'None',
+                'Port': '2101',
+                'Site': 'http://sample.htm'
+            }
+        ],
+        'net': [],
+        'str': []
+    }
+
+
+@patch.object(NtripBrowser, '_read_data', lambda self, url: testing_content.VALID_NTRIP)
+def test_valid_data():
+    browser = NtripBrowser('test', 1234)
+    assert browser.get_mountpoints() == {
+        'cas': [
+            {
+                'Country': 'Null',
+                'Distance': None,
+                'FallbackHost': '1.2.3.4',
+                'FallbackPort': '5',
+                'Host': 'example',
+                'ID': 'NtripCaster',
+                'Latitude': '11',
+                'Longitude': '22.33',
+                'NMEA': '0',
+                'Operator': 'None',
+                'Port': '2101',
+                'Site': 'http://sample.htm'
+            }
+        ],
+        'net': [
+            {
+                'Authentication': 'B',
+                'Distance': None,
+                'Fee': 'N',
+                'ID': 'Str1',
+                'Operator': 'Str2',
+                'Other Details': 'none',
+                'Web-Net': 'https://example.htm',
+                'Web-Reg': 'http://sample',
+                'Web-Str': 'http://example.htm'
+            }
+        ],
+        'str': [
+            {
+                'Carrier': 'https://example2.htm',
+                'Country': 'none',
+                'Distance': None,
+                'Format': 'B',
+                'Format-Details': 'N',
+                'ID': 'Str4',
+                'Mountpoint': 'Str3',
+                'Nav-System': 'http://example2.htm',
+                'Network': 'http://sample2'
+             }
+        ]
+    }
+
+
+@patch.object(NtripBrowser, '_read_data', lambda self, url: testing_content.VALID_NTRIP)
+def test_add_coordinates():
+    browser = NtripBrowser('test', 1234, coordinates=(1.0, 2.0))
+    assert browser.get_mountpoints() == {
+        'cas': [
+            {
+                'Country': 'Null',
+                'Distance': 2505.0572138274565,
+                'FallbackHost': '1.2.3.4',
+                'FallbackPort': '5',
+                'Host': 'example',
+                'ID': 'NtripCaster',
+                'Latitude': '11',
+                'Longitude': '22.33',
+                'NMEA': '0',
+                'Operator': 'None',
+                'Port': '2101',
+                'Site': 'http://sample.htm'
+            }
+        ],
+        'net': [
+            {
+                'Authentication': 'B',
+                'Distance': 248.57556516798113,
+                'Fee': 'N',
+                'ID': 'Str1',
+                'Operator': 'Str2',
+                'Other Details': 'none',
+                'Web-Net': 'https://example.htm',
+                'Web-Reg': 'http://sample',
+                'Web-Str': 'http://example.htm'
+            }
+        ],
+        'str': [
+            {
+                'Carrier': 'https://example2.htm',
+                'Country': 'none',
+                'Distance': 248.57556516798113,
+                'Format': 'B',
+                'Format-Details': 'N',
+                'ID': 'Str4',
+                'Mountpoint': 'Str3',
+                'Nav-System': 'http://example2.htm',
+                'Network': 'http://sample2'
+             }
+        ]
+    }

--- a/tests/testing_content.py
+++ b/tests/testing_content.py
@@ -1,0 +1,17 @@
+VALID_NET_NTRIP = b'SOURCETABLE 200 OK \n' \
+                  b'NET;Str1;Str2;B;N;https://example.htm;http://example.htm;http://sample;none\n' \
+                  b'ENDSOURCETABLE'
+
+VALID_STR_NTRIP = b'SOURCETABLE 200 OK \n' \
+                  b'STR;Str3;Str4;B;N;https://example2.htm;http://example2.htm;http://sample2;none\n' \
+                  b'ENDSOURCETABLE'
+
+VALID_CAS_NTRIP = b'SOURCETABLE 200 OK \n' \
+                  b'CAS;example;2101;NtripCaster;None;0;Null;11;22.33;1.2.3.4;5;http://sample.htm\n' \
+                  b'ENDSOURCETABLE'
+
+VALID_NTRIP = b'SOURCETABLE 200 OK \n' \
+              b'CAS;example;2101;NtripCaster;None;0;Null;11;22.33;1.2.3.4;5;http://sample.htm\n' \
+              b'STR;Str3;Str4;B;N;https://example2.htm;http://example2.htm;http://sample2;none\n' \
+              b'NET;Str1;Str2;B;N;https://example.htm;http://example.htm;http://sample;none\n' \
+              b'ENDSOURCETABLE'

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+envlist = py27,py36
+[testenv]
+deps=
+  mock
+  pytest
+  pytest-xdist
+commands=
+  pytest -vv --basetemp={envtmpdir} --confcutdir=.. -n 2 {posargs}


### PR DESCRIPTION
Pr contains several improvements:
- `NtripBrowser` became a class.
 - Fixed the the method of obtaining data from casters(`urllib2` -> `pycurl`). It's caused by ntrip protocol difference with the HTTP standard. NTRIP does not support default HTTP status codes.
 - Fixed bug with casters(e.g. `193.190.66.25:2102`) that transmit http/https pages with standard status codes(`200`, `400` etc.).
 - Added possibility to browse ntrip from https casters (e.g. `https://cddis-caster.gsfc.nasa.gov:443'`).
 - Changed `geopy.distance.vincenty` -> `geopy.distance.geodesic`. This is necessary because `vincenty()` method is deprecated.
 - Added Python3 support.
 - Namings fixed.
 - Logging added.
 - Exceptions updated.
 - Formatting fixed.
 - Browser cli creation moved to another file.
 - API updated, now it's possible to reassign `host`, `port`, `timeout`, `coordinates` for existing `NtripBrowser` instance.
 - Most methods reworked.
 - Methods & variables namings fixed according to ntripbrowser changes.
 - New exceptions handling added.
 - Subprocess `stty size` -> `pager.getwidth()`.
 - Tests added.
 - Tox tests automatization added. Now it is possible to test ntripbrowser on Python2 and Python3.
 - README.md updated.
 - Added automatic testing using the semaphoreci.