### PR TITLE
Fix distance calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ A Python API for browsing NTRIP (Networked Transport of RTCM via Internet Protoc
 
  -  or clone and run `make install`
 
+ - If you are looking for the last Python2 version of this package, checkout onto v2.2.3 tag. Python2 support will be discontinued in future releases. 
+
+```
+    git checkout v2.2.3
+```
+
 #### libcurl installation hints
 
  - installation via `apt`:

--- a/ntripbrowser/ntripbrowser.py
+++ b/ntripbrowser/ntripbrowser.py
@@ -280,7 +280,11 @@ class NtripBrowser(object):
 
     def _get_distance(self, obs_point):
         if self.coordinates:
-            return geodesic(obs_point, self.coordinates).kilometers
+            try:
+                return geodesic(obs_point, self.coordinates).kilometers
+            except ValueError:
+                logger.warning("Unable calculate the geodesic distance between points, %s, %s",
+                               obs_point, self.coordinates)
         return None
 
     def _trim_outlying(self, ntrip_dictionary):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(path.join(this_directory, 'README.md')) as f:
 
 setup(
     name='ntripbrowser',
-    version='2.2.2',
+    version='2.2.3',
     author='Andrew Yushkevich, Alexander Yashin',
     author_email='andrew.yushkevich@emlid.com, alexandr.yashin@emlid.com',
     packages=['ntripbrowser'],


### PR DESCRIPTION
Some casters(e.g. `gps.sit.regione.campania.it`) provided incorrect observation points coordinates which must be [-90; 90].